### PR TITLE
fix: 🐛 rename package to include org name prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tsconfigs",
-  "version": "1.1.1",
+  "name": "@glaminstants/tsconfigs",
+  "version": "1.1.2",
   "private": true,
   "repository": "git@github.com:glaminstants/tsconfigs.git",
   "author": "Fábio Ferreira <ffcfpten@gmail.com>",


### PR DESCRIPTION
## In this PR:
- Rename package to include org name prefix.